### PR TITLE
feat: Optimize Docker build with multi-stage process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,63 @@
-FROM python:3.12-slim
-
-ENV PYTHONUNBUFFERED=1
+# ---- Builder Stage ----
+# This stage installs node, npm dependencies, and generates the prisma client.
+FROM node:18-slim as builder
 
 WORKDIR /app
 
-# Instalar dependencias del sistema necesarias para compilar paquetes nativos
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    libpq-dev \
-    gcc \
-    postgresql-client
-
-# Actualizar pip
-RUN python -m pip install --upgrade pip
-
-# Copiar requirements e instalar dependencias Python
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt \
-    && apt-get purge -y --auto-remove build-essential gcc libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Instala Node.js y npm (necesario para Prisma)
-RUN apt-get update && apt-get install -y npm && rm -rf /var/lib/apt/lists/*
-
-#Copia los package
+# Copy package files
 COPY package*.json ./
 
-# Instala el CLI
+# Install JS dependencies (including prisma CLI)
 RUN npm install
 
-# Copiar código de la aplicación
+# Copy prisma schema
+COPY prisma ./prisma/
+
+# Generate the Prisma client. This is the memory-intensive step.
+# The output path is now explicitly configured in schema.prisma.
+RUN npx prisma generate
+
+# ---- Final Stage ----
+# This is the final, lean production image.
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+# This environment variable ensures that prisma-client-py downloads the correct
+# binary for the Debian-based slim image.
+ENV PRISMA_CLI_QUERY_ENGINE_BINARY_TARGETS=debian-openssl-3.0.x
+
+WORKDIR /app
+
+# Install runtime system dependencies.
+# postgresql-client is needed for psycopg2 to connect to PostgreSQL.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip
+RUN python -m pip install --upgrade pip
+
+# Install Python dependencies from requirements.txt
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application code
 COPY . .
 
-# Limitar paralelismo
-ENV PRISMA_CLI_QUERY_ENGINE_BINARY_TARGETS=debian-openssl-3.0.x
-ENV PRISMA_CLI_ENGINE_TYPE=binary
+# Copy the pre-generated Prisma client from the builder stage.
+COPY --from=builder /app/app/infrastructure/database/prisma_client.py ./app/infrastructure/database/prisma_client.py
 
-# Generate models
-RUN npx prisma generate --no-engine
-
-# Crear usuario no-root y ajustar permisos
+# Create a non-root user for security.
 RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser \
     && chown -R appuser:appuser /app
 
+# Switch to the non-root user.
 USER appuser
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "npx prisma generate && npx prisma migrate deploy && uvicorn main:app --host 0.0.0.0 --port 8000"]
+# The command to run the application.
+# We first apply any pending database migrations and then start the uvicorn server.
+# We use `python -m prisma` which is available from the `prisma-client-py` package.
+# This avoids needing Node.js in the final image.
+CMD ["sh", "-c", "python -m prisma migrate deploy && uvicorn main:app --host 0.0.0.0 --port 8000"]

--- a/NORTHFLANK_DEPLOY.md
+++ b/NORTHFLANK_DEPLOY.md
@@ -1,0 +1,68 @@
+# 🚀 Guía de Despliegue en Northflank
+
+Esta guía te ayudará a desplegar la aplicación optimizada en Northflank, aprovechando el `Dockerfile` multi-etapa que hemos creado.
+
+## Resumen de la Optimización
+
+El `Dockerfile` ha sido reestructurado para usar un **build multi-etapa**. Esto resuelve el problema de alto consumo de memoria de la siguiente manera:
+
+1.  **Etapa de `builder`**: Una imagen temporal con Node.js se encarga de la tarea pesada de generar el cliente de Prisma (`prisma generate`).
+2.  **Etapa final**: La imagen final es ligera, basada en `python:3.12-slim`. No contiene Node.js ni las dependencias de desarrollo. Solo copia el cliente de Prisma ya generado desde la etapa de `builder`.
+
+Esto resulta en una **imagen Docker más pequeña y un menor consumo de memoria** durante el despliegue y la ejecución.
+
+---
+
+## 📋 Pasos para Desplegar en Northflank
+
+Aunque no puedo acceder a tu cuenta de Northflank, aquí tienes los pasos generales que deberías seguir en su plataforma.
+
+### 1. Conectar tu Repositorio de Git
+
+-   En tu proyecto de Northflank, ve a la sección de **"Code"** o **"Repositories"**.
+-   Conecta tu cuenta de Git (GitHub, GitLab, Bitbucket, etc.) y selecciona el repositorio que contiene esta aplicación.
+
+### 2. Configurar el Servicio de Despliegue
+
+-   Crea un nuevo **servicio** en Northflank. Elige el tipo **"Deployment"** o **"Combined"** (si también necesitas una base de datos).
+-   **Fuente del Repositorio**:
+    -   **Repositorio**: Selecciona el repositorio que acabas de conectar.
+    -   **Branch**: Elige la rama que quieres desplegar (ej. `main` o la rama con estos cambios).
+
+### 3. Configurar el Build
+
+Esta es la parte más importante.
+
+-   En la configuración del servicio, busca la sección de **"Build Settings"** o **"Build Options"**.
+-   **Tipo de Build**: Elige **`Dockerfile`**.
+-   **Ruta del Dockerfile**:
+    -   Asegúrate de que Northflank apunte al `Dockerfile` en la raíz del repositorio. El path debería ser `Dockerfile`. Northflank normalmente lo detecta automáticamente si está en la raíz.
+
+### 4. Configurar Variables de Entorno
+
+-   Ve a la sección de **"Environment Variables"** o **"Secrets"** de tu servicio.
+-   Añade la variable de entorno `DATABASE_URL` con el valor correcto para tu base de datos de producción en Northflank.
+    -   **Ejemplo**: `postgresql://user:password@host:port/dbname`
+-   Añade cualquier otra variable de entorno que tu aplicación necesite (revisa tu archivo `.env.example`).
+
+### 5. Configurar el Comando de Inicio (Opcional)
+
+-   El `Dockerfile` ya incluye un `CMD` para iniciar la aplicación.
+-   `CMD ["sh", "-c", "python -m prisma migrate deploy && uvicorn main:app --host 0.0.0.0 --port 8000"]`
+-   Northflank debería usar este comando por defecto. Si te pide un "start command" o "runtime command", puedes dejarlo en blanco para que use el del `Dockerfile`.
+
+### 6. Desplegar
+
+-   Guarda la configuración del servicio.
+-   Northflank debería iniciar el proceso de build y despliegue automáticamente.
+-   Puedes monitorear los logs del build para asegurarte de que todo el proceso se completa sin errores. Con el `Dockerfile` optimizado, el paso de `prisma generate` no debería causar problemas de memoria.
+
+---
+
+## ✅ Verificación Post-Despliegue
+
+1.  **Logs del Build**: Revisa que el build se complete exitosamente.
+2.  **Logs de Runtime**: Una vez desplegado, revisa los logs de la aplicación para confirmar que se conecta a la base de datos y que el servidor `uvicorn` se inicia correctamente.
+3.  **Endpoint Público**: Accede a la URL pública que Northflank te proporcione para verificar que la API responde.
+
+Con estos pasos, tu aplicación debería desplegarse de manera eficiente y sin los errores de memoria que estabas experimentando.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,6 +2,7 @@ generator client {
   provider             = "prisma-client-py"
   interface            = "asyncio"
   recursive_type_depth = "5"
+  output               = "../app/infrastructure/database/prisma_client.py"
 }
 
 datasource db {


### PR DESCRIPTION
This commit introduces a multi-stage Dockerfile to address out-of-memory errors during deployment.

The key changes are:
- A 'builder' stage is used to install Node.js dependencies and run the memory-intensive `prisma generate` command.
- The final image is a lean Python image that copies the pre-generated Prisma client, significantly reducing its size and runtime memory footprint.
- The `prisma/schema.prisma` file is updated to specify an explicit output path for the client, ensuring a predictable build process.
- The startup command now uses `python -m prisma migrate deploy`, removing the need for Node.js in the final image.
- A `NORTHFLANK_DEPLOY.md` file has been added to provide deployment instructions for the user.